### PR TITLE
remove network permission

### DIFF
--- a/ar.xjuan.Cambalache.json
+++ b/ar.xjuan.Cambalache.json
@@ -7,7 +7,6 @@
     "command" : "cambalache",
     "finish-args" : [
         "--share=ipc",
-        "--share=network",
         "--socket=fallback-x11",
         "--socket=wayland",
         "--filesystem=home",


### PR DESCRIPTION
broadway with webkit needed it but now the app uses wlroots which doesn't need it