### PR TITLE
fixed Bug Gtk4 < 4.23

### DIFF
--- a/ar.xjuan.Cambalache.json
+++ b/ar.xjuan.Cambalache.json
@@ -11,7 +11,8 @@
     "--socket=fallback-x11",
     "--socket=wayland",
     "--filesystem=home",
-    "--device=dri"
+    "--device=dri",
+    "--env=GSK_RENDERER=gl"
   ],
   "cleanup": [
     "/include",


### PR DESCRIPTION
Fixed update #68 is needed 

--env=GSK_RENDERER=gl

This line corrects the GTK4 < 4.23 problem because it forces the use of OpenGL to render what is not available. When Gnome 51 is released, this line would no longer be necessary; they would simply have to remove it.

